### PR TITLE
Disable seeds to allow migrations

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,5 +5,5 @@ set -o errexit
 
 npm run build
 bundle install
-rails db:migrate
 rails db:seed #if needed. Remove this when you are super production ready to avoid dropping tables and user accounts.
+rails db:migrate

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,12 +17,12 @@ puts "Primary key sequence reset"
 # Sample data
 puts "Creating Users"
 # This is the demo user.
-ike = User.create!(
-  email: "eisenhower@ike.com",
-  password: "ilikeike",
-  first_name: "Dwight",
-  last_name: "Eisenhower"
-)
+# ike = User.create!(
+#   email: "eisenhower@ike.com",
+#   password: "ilikeike",
+#   first_name: "Dwight",
+#   last_name: "Eisenhower"
+# )
 
 # 10.times do
 #   User.create!({


### PR DESCRIPTION
Moved up the rails db:seed command so we drop the tables and don't create seeds. Then the migration command can run w/o failure. Demo user will be broken unless we recreate it with the sign up form