### PR TITLE
Remove non-ticket events when from page when users remove tickets

### DIFF
--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -10,8 +10,8 @@ export default function Footer() {
         <div className="footer-one">
           <h3>About Me</h3>
           <p>Julio Uribe</p>
-          <p><a href="https://www.linkedin.com/in/julio-uribe-a15736b5/">LinkedIn</a></p>
-          <p><a href="https://github.com/juliouribe">Github</a></p>
+          <p><a href="https://www.linkedin.com/in/julio-uribe-a15736b5/" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
+          <p><a href="https://github.com/juliouribe" target="_blank" rel="noopener noreferrer">Github</a></p>
         </div>
         <div className="footer-two">
           <h3>Frontend</h3>

--- a/frontend/src/components/UserTickets/index.jsx
+++ b/frontend/src/components/UserTickets/index.jsx
@@ -10,8 +10,7 @@ export default function UserTickets() {
   const currentUser = useSelector(state => state.session.currentUser);
   const eventsObj = useSelector(getEvents());
   const events = Object.values(eventsObj);
-  const ticketsObj = useSelector(state => state.entities.tickets);
-  const tickets = Object.values(ticketsObj);
+  const tickets = Object.values(useSelector(state => state.entities.tickets));
 
   events.sort((a, b) => {
     return new Date(a.startTime) - new Date(b.startTime);
@@ -40,6 +39,7 @@ export default function UserTickets() {
         <div className="hosted-events">
           {events.map((event) => {
             const ticket = tickets.find(ticket => ticket.eventId === event.id)
+            if (!ticket) return null;
             return <UserEventItem key={event.id} event={event} owner={false} ticket={ticket} />
           })}
         </div>


### PR DESCRIPTION
- Add new tab functionality for socials
- When you remove tickets, re-render the page appropriately while dropping those old tickets. Prevents users from trying to update non-existent tickets